### PR TITLE
Adding UTC standarization

### DIFF
--- a/nfdump/bin/nfcapd.c
+++ b/nfdump/bin/nfcapd.c
@@ -762,6 +762,10 @@ srecord_t	*commbuff;
 
 int main(int argc, char **argv) {
  
+//Set timezone to UTC f or standarization.
+setenv("TZ","UTC",1);
+tzset();
+
 char	*bindhost, *filter, *datadir, pidstr[32], *launch_process;
 char	*userid, *groupid, *checkptr, *listenport, *mcastgroup, *extension_tags;
 char	*Ident, *dynsrcdir, pidfile[MAXPATHLEN];

--- a/nfdump/bin/nfdump.c
+++ b/nfdump/bin/nfdump.c
@@ -725,6 +725,11 @@ time_t 		t_start, t_end;
 uint32_t	limitflows;
 char 		Ident[IDENTLEN];
 
+
+    //Set timezone to UTC for standarization.
+    setenv("TZ","UTC",1);
+    tzset();
+
 	rfile = Rfile = Mdirs = wfile = ffile = filter = tstring = stat_type = NULL;
 	byte_limit_string = packet_limit_string = NULL;
 	fdump = aggregate = 0;


### PR DESCRIPTION
Modify nfdump and nfcapd to use UTC (time zone) by default, 
Change : use TZ environment variable , set this variable to "UTC" to fix time shifted issue.
